### PR TITLE
Update README with skills, initiatives, and improved bio

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently building:
 * **Senior Director of Product at Playvox** — led the creation of a new AI-powered [AutoQA](https://www.prnewswire.com/news-releases/playvox-announces-autoqa-to-transform-quality-assurance-with-the-power-of-ai-301626443.html) product
 * **Founder & CEO at Prodsight** — built a conversational AI startup, [acquired](https://www.prnewswire.com/news-releases/playvox-introduces-customer-ai-with-the-acquisition-of-prodsight-301458125.html) by Playvox in 2022
 * **Product Manager at Yavi** — first PM at a messaging app for scheduled workers
-* **Product Manager at Kotikan**
+* **Product Manager at Kotikan** — worked on 0-1 mobile products
 
 ## Copilot Skills
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Currently building:
 * **Founder & CEO at Prodsight** — built a conversational AI startup, [acquired](https://www.prnewswire.com/news-releases/playvox-introduces-customer-ai-with-the-acquisition-of-prodsight-301458125.html) by Playvox in 2022
 * **Product Manager at Yavi** — first PM at a messaging app for scheduled workers
 
+## Copilot Skills
+
+* [mockup-prototype](https://github.com/labudis/skills/tree/main/mockup-prototype) — generate interactive HTML mockups from a description, iterate on them, and deploy to GitHub Pages or Vercel for sharing
+* [github-issues](https://github.com/awesome-copilot/github-issues) — create, update, and manage GitHub issues using MCP tools and `gh` CLI
+
 ## Find me on
 
 * [LinkedIn](https://www.linkedin.com/in/tadaslabudis/)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Currently building:
 ## Previously
 
 * **Senior Director of Product at Playvox** — led the creation of a new AI-powered [AutoQA](https://www.prnewswire.com/news-releases/playvox-announces-autoqa-to-transform-quality-assurance-with-the-power-of-ai-301626443.html) product
-* **Founder & CEO at Prodsight** — built a conversational AI startup, [acquired](https://www.prnewswire.com/news-releases/playvox-introduces-customer-ai-with-the-acquisition-of-prodsight-301458125.html) by Playvox in 2022
+* **Founder & CEO at Prodsight** — built an AI-powered customer feedback analytics platform using NLP to auto-tag and analyze support tickets, reviews, and surveys; [acquired](https://www.prnewswire.com/news-releases/playvox-introduces-customer-ai-with-the-acquisition-of-prodsight-301458125.html) by Playvox in 2022
 * **Product Manager at Yavi** — founding PM at a workforce management startup combining mobile messaging with shift scheduling
 * **Product Manager at Kotikan** — worked on 0-1 mobile products at the agency behind Skyscanner and FanDuel's mobile apps
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Product leader who loves building and scaling products.
 
 **Senior Product Manager at GitHub**, working on Issues.
 
-Currently building:
+Key initiatives:
 * [Issue fields](https://github.com/orgs/community/discussions/189141) — typed, org-wide custom fields on issues (single-select, text, number, date) with search, API, and Projects integration
 * Triage agent — AI-powered agent that automatically triages incoming issues
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently building:
 
 * **Senior Director of Product at Playvox** — led the creation of a new AI-powered [AutoQA](https://www.prnewswire.com/news-releases/playvox-announces-autoqa-to-transform-quality-assurance-with-the-power-of-ai-301626443.html) product
 * **Founder & CEO at Prodsight** — built a conversational AI startup, [acquired](https://www.prnewswire.com/news-releases/playvox-introduces-customer-ai-with-the-acquisition-of-prodsight-301458125.html) by Playvox in 2022
-* **Product Manager at Yavi** — first PM at a messaging app for scheduled workers
+* **Product Manager at Yavi** — first PM at a mobile messaging and scheduling app for workforce management
 * **Product Manager at Kotikan** — worked on 0-1 mobile products at the agency behind Skyscanner and FanDuel's mobile apps
 
 ## Copilot Skills

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently building:
 
 * **Senior Director of Product at Playvox** — led the creation of a new AI-powered [AutoQA](https://www.prnewswire.com/news-releases/playvox-announces-autoqa-to-transform-quality-assurance-with-the-power-of-ai-301626443.html) product
 * **Founder & CEO at Prodsight** — built a conversational AI startup, [acquired](https://www.prnewswire.com/news-releases/playvox-introduces-customer-ai-with-the-acquisition-of-prodsight-301458125.html) by Playvox in 2022
-* **Product Manager at Yavi** — first PM at a mobile messaging and scheduling app for workforce management
+* **Product Manager at Yavi** — founding PM at a workforce management startup combining mobile messaging with shift scheduling
 * **Product Manager at Kotikan** — worked on 0-1 mobile products at the agency behind Skyscanner and FanDuel's mobile apps
 
 ## Copilot Skills

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Product leader who loves building and scaling products.
 Key initiatives:
 * [Issue fields](https://github.blog/changelog/2026-03-12-issue-fields-structured-issue-metadata-is-in-public-preview) — structured metadata on issues, replacing the workarounds teams built with labels and project fields
 * [Semantic search](https://github.blog/changelog/2026-01-29-improved-search-for-github-issues-in-public-preview/) — natural language search for GitHub Issues
+* [Copilot repo and branch selection](https://github.blog/changelog/2025-09-24-pick-the-repository-and-base-branch-when-assigning-issues-to-copilot/) — pick the target repo and base branch when assigning issues to Copilot
 * Triage agent — AI-powered agent that automatically triages incoming issues
 
 ## Previously

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Product leader who loves building and scaling products.
 **Senior Product Manager at GitHub**, working on Issues.
 
 Currently building:
-* [Issue fields](https://github.com/orgs/community/discussions/189141)
-* Triage agent
+* [Issue fields](https://github.com/orgs/community/discussions/189141) — typed, org-wide custom fields on issues (single-select, text, number, date) with search, API, and Projects integration
+* Triage agent — AI-powered agent that automatically triages incoming issues
 
 ## Previously
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Product leader who loves building and scaling products.
 **Senior Product Manager at GitHub**, working on Issues.
 
 Key initiatives:
-* [Issue fields](https://github.com/orgs/community/discussions/189141) — structured metadata on issues, replacing the workarounds teams built with labels and project fields
+* [Issue fields](https://github.blog/changelog/2026-03-12-issue-fields-structured-issue-metadata-is-in-public-preview) — structured metadata on issues, replacing the workarounds teams built with labels and project fields
 * [Semantic search](https://github.blog/changelog/2026-01-29-improved-search-for-github-issues-in-public-preview/) — natural language search for GitHub Issues
 * Triage agent — AI-powered agent that automatically triages incoming issues
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Product manager at GitHub, building the future of Issues. Previously founded Prodsight (acquired by Playvox) and shipped AI products across customer support, feedback analytics, and developer tools.
 
-## Now
+## 🚀 Now
 
 **Senior Product Manager at GitHub**, working on Issues.
 
@@ -12,20 +12,20 @@ Key initiatives:
 * [Copilot repo and branch selection](https://github.blog/changelog/2025-09-24-pick-the-repository-and-base-branch-when-assigning-issues-to-copilot/) — pick the target repo and base branch when assigning issues to Copilot
 * Triage agent — AI-powered agent that automatically triages incoming issues
 
-## Previously
+## 🏗️ Previously
 
 * **Senior Director of Product at Playvox** — created [AutoQA](https://www.prnewswire.com/news-releases/playvox-announces-autoqa-to-transform-quality-assurance-with-the-power-of-ai-301626443.html), an AI product that automated quality scoring across 100% of customer support interactions
 * **Founder & CEO at Prodsight** — built an AI-powered customer feedback analytics platform using NLP to auto-tag and analyze support tickets, reviews, and surveys; [acquired](https://www.prnewswire.com/news-releases/playvox-introduces-customer-ai-with-the-acquisition-of-prodsight-301458125.html) by Playvox in 2022
 * **Product Manager at Yavi** — founding PM at a workforce management startup combining mobile messaging with shift scheduling
 * **Product Manager at Kotikan** — worked on 0-1 mobile products at the agency behind Skyscanner and FanDuel's mobile apps
 
-## Copilot Skills
+## 🤖 Copilot Skills
 
 * [mockup-prototype](https://skills.sh/labudis/skills/mockup-prototype) — generate interactive HTML mockups from a description, iterate on them, and deploy to GitHub Pages or Vercel for sharing
 * [github-issues](https://skills.sh/github/awesome-copilot/github-issues) — create, update, and manage GitHub issues using MCP tools and `gh` CLI
 * [issue-fields-migration](https://skills.sh/github/awesome-copilot/issue-fields-migration) — bulk-copy field values from Project V2 fields or repo labels to org-level issue fields
 
-## Find me on
+## 🔗 Find me on
 
 * [LinkedIn](https://www.linkedin.com/in/tadaslabudis/)
 * [X](https://x.com/tadaslab)

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Product leader who loves building and scaling products.
 **Senior Product Manager at GitHub**, working on Issues.
 
 Key initiatives:
-* [Issue fields](https://github.com/orgs/community/discussions/189141) — typed, org-wide custom fields on issues (single-select, text, number, date) with search, API, and Projects integration
+* [Issue fields](https://github.com/orgs/community/discussions/189141) — structured metadata on issues, replacing the workarounds teams built with labels and project fields
 * Triage agent — AI-powered agent that automatically triages incoming issues
 
 ## Previously

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Currently building:
 * **Senior Director of Product at Playvox** — led the creation of a new AI-powered [AutoQA](https://www.prnewswire.com/news-releases/playvox-announces-autoqa-to-transform-quality-assurance-with-the-power-of-ai-301626443.html) product
 * **Founder & CEO at Prodsight** — built a conversational AI startup, [acquired](https://www.prnewswire.com/news-releases/playvox-introduces-customer-ai-with-the-acquisition-of-prodsight-301458125.html) by Playvox in 2022
 * **Product Manager at Yavi** — first PM at a messaging app for scheduled workers
+* **Product Manager at Kotikan**
 
 ## Copilot Skills
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hi, I'm Tadas 👋
 
-Product leader who loves building and scaling products.
+Product manager at GitHub, building the future of Issues. Previously founded Prodsight (acquired by Playvox) and shipped AI products across customer support, feedback analytics, and developer tools.
 
 ## Now
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Product leader who loves building and scaling products.
 **Senior Product Manager at GitHub**, working on Issues.
 
 Currently building:
-* Issue fields
+* [Issue fields](https://github.com/orgs/community/discussions/189141)
 * Triage agent
 
 ## Previously

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Currently building:
 
 ## Previously
 
-* **Senior Director of Product at Playvox** — led the creation of a new AI-powered [AutoQA](https://www.prnewswire.com/news-releases/playvox-announces-autoqa-to-transform-quality-assurance-with-the-power-of-ai-301626443.html) product
+* **Senior Director of Product at Playvox** — created [AutoQA](https://www.prnewswire.com/news-releases/playvox-announces-autoqa-to-transform-quality-assurance-with-the-power-of-ai-301626443.html), an AI product that automated quality scoring across 100% of customer support interactions
 * **Founder & CEO at Prodsight** — built an AI-powered customer feedback analytics platform using NLP to auto-tag and analyze support tickets, reviews, and surveys; [acquired](https://www.prnewswire.com/news-releases/playvox-introduces-customer-ai-with-the-acquisition-of-prodsight-301458125.html) by Playvox in 2022
 * **Product Manager at Yavi** — founding PM at a workforce management startup combining mobile messaging with shift scheduling
 * **Product Manager at Kotikan** — worked on 0-1 mobile products at the agency behind Skyscanner and FanDuel's mobile apps

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ Currently building:
 
 ## Copilot Skills
 
-* [mockup-prototype](https://github.com/labudis/skills/tree/main/mockup-prototype) — generate interactive HTML mockups from a description, iterate on them, and deploy to GitHub Pages or Vercel for sharing
-* [github-issues](https://github.com/awesome-copilot/github-issues) — create, update, and manage GitHub issues using MCP tools and `gh` CLI
+* [mockup-prototype](https://skills.sh/labudis/skills/mockup-prototype) — generate interactive HTML mockups from a description, iterate on them, and deploy to GitHub Pages or Vercel for sharing
+* [github-issues](https://skills.sh/github/awesome-copilot/github-issues) — create, update, and manage GitHub issues using MCP tools and `gh` CLI
+* [issue-fields-migration](https://skills.sh/github/awesome-copilot/issue-fields-migration) — bulk-copy field values from Project V2 fields or repo labels to org-level issue fields
 
 ## Find me on
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Product leader who loves building and scaling products.
 
 Key initiatives:
 * [Issue fields](https://github.com/orgs/community/discussions/189141) — structured metadata on issues, replacing the workarounds teams built with labels and project fields
+* [Semantic search](https://github.blog/changelog/2026-01-29-improved-search-for-github-issues-in-public-preview/) — natural language search for GitHub Issues
 * Triage agent — AI-powered agent that automatically triages incoming issues
 
 ## Previously

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Currently building:
 * **Senior Director of Product at Playvox** — led the creation of a new AI-powered [AutoQA](https://www.prnewswire.com/news-releases/playvox-announces-autoqa-to-transform-quality-assurance-with-the-power-of-ai-301626443.html) product
 * **Founder & CEO at Prodsight** — built a conversational AI startup, [acquired](https://www.prnewswire.com/news-releases/playvox-introduces-customer-ai-with-the-acquisition-of-prodsight-301458125.html) by Playvox in 2022
 * **Product Manager at Yavi** — first PM at a messaging app for scheduled workers
-* **Product Manager at Kotikan** — worked on 0-1 mobile products
+* **Product Manager at Kotikan** — worked on 0-1 mobile products at the agency behind Skyscanner and FanDuel's mobile apps
 
 ## Copilot Skills
 


### PR DESCRIPTION
Updates the profile README with:

- **Bio**: replaced generic tagline with career narrative
- **Key initiatives**: Issue fields, semantic search, Copilot repo/branch selection, triage agent (with changelog links)
- **Copilot Skills**: mockup-prototype, github-issues, issue-fields-migration (with skills.sh links)
- **Previously**: added Kotikan role, improved descriptions for all roles (Prodsight, Playvox AutoQA, Yavi)